### PR TITLE
Implement YAML/Dictionary-based storage scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Waifus.txt
 failedList*.txt
 bot/testing.py
 prune.py
+info.txt

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode
 img/waifu
 guilds/*.p
+guilds/*.yaml
 postgre
 __pycache__
 utilities

--- a/bot/cogs/utilityCogs.py
+++ b/bot/cogs/utilityCogs.py
@@ -3,6 +3,7 @@ from asyncio import Lock, run
 import logging, os
 from statistics import stdev
 import glob
+from guilds import Server
 #local imports
 import database, images
 from headpatBot import HeadpatBot
@@ -125,6 +126,34 @@ class TestCog(commands.Cog):
         with open('info.txt','rb') as fileRaw:
             file=File(fileRaw,filename='info.txt')
             await inter.send(f'storing',file=file)
+
+    @commands.slash_command()
+    async def dump_dict(self,inter:ApplicationCommandInteraction):
+        await inter.response.defer(ephemeral=True)
+        server1=self.bot.servers[inter.guild.id]
+        with open('info.txt','w') as file:
+            file.write("Safe Dumping Server With Load")
+            file.write('\n---\nRaw server:\n')
+            file.write(str(server1))
+            dict1 = server1.getStorageDict()
+            file.write('\n---\ndictionary:\n')
+            file.write(str(dict1))
+            file.write('\n---\nsafe yaml:\n')
+            yaml1=str(yaml.safe_dump(dict1))
+            file.write(yaml1)
+            dict2=yaml.safe_load(yaml1)
+            file.write('\n---\nloaded dict:\n')
+            file.write(str(dict2))
+            server2 = Server.buildFromDict(dict1)
+            file.write('\n---\nserver from original dict:\n')
+            file.write(str(server2))
+            server3 = Server.buildFromDict(dict2)
+            file.write('\n---\nserver from loaded dict:\n')
+            file.write(str(server3))
+            
+        with open('info.txt','rb') as fileRaw:
+            file=File(fileRaw,filename='info.txt')
+            await inter.send(f'as dictionary',file=file,ephemeral=True)
 
     @commands.slash_command()
     async def ratings(self,inter):

--- a/bot/cogs/utilityCogs.py
+++ b/bot/cogs/utilityCogs.py
@@ -44,7 +44,7 @@ class TimerCog(commands.Cog):
         self.logger.info('Saving filesystem to database')
         async with self.dbLock:
             for server in self.bot.servers.values():
-                await database.storeGuildPickle(server)
+                await database.storeGuild(server)
             for waifuImage in glob.glob('*/*/*.qoi',root_dir=images.POLL_FOLDER):
                 waifuData=waifuImage.split('/')
                 imagePath=os.path.join(images.POLL_FOLDER,waifuImage)
@@ -122,7 +122,7 @@ class TestCog(commands.Cog):
         server=self.bot.servers[inter.guild.id]
         with open('info.txt','w') as file:
             file.write(str(server))
-        await database.storeGuildPickle(server)
+        await database.storeGuild(server)
         with open('info.txt','rb') as fileRaw:
             file=File(fileRaw,filename='info.txt')
             await inter.send(f'storing',file=file)

--- a/bot/cogs/utilityCogs.py
+++ b/bot/cogs/utilityCogs.py
@@ -69,7 +69,7 @@ class TimerCog(commands.Cog):
                     images.saveRawPollImage(waifuImage,waifuHash,images.sourceNameFolder(name,source))
             allGuilds=await database.getAllGuilds()
             for guildId in allGuilds:
-                guild = await database.getGuildPickle(guildId)
+                guild = await database.getGuild(guildId)
                 guild.save()
 
     @tasks.loop(hours=3)

--- a/bot/guilds.py
+++ b/bot/guilds.py
@@ -147,14 +147,21 @@ class Server:
     def delete(self):
         filePath=os.path.join(SAVE_FOLDER,f'{self.identity}.p')
         os.remove(filePath)
+        filePath=os.path.join(SAVE_FOLDER,f'{self.identity}.yaml')
+        os.remove(filePath)
 
     @staticmethod
     def load(identity:int) -> Server:
-        try:
-            with open(os.path.join(SAVE_FOLDER,f'{identity}.p'),'rb') as loadFile:
-                loaded = pickle.load(loadFile)
-        except FileNotFoundError:
-            loaded=Server(identity)
+        try: #load from YAML
+            with open(os.path.join(SAVE_FOLDER,f'{identity}.yaml'),'rb') as loadFile:
+                dict=yaml.safe_load(loadFile)
+                loaded=Server.buildFromDict(dict)
+        except FileNotFoundError: #go to a pickle
+            try:
+                with open(os.path.join(SAVE_FOLDER,f'{identity}.p'),'rb') as loadFile:
+                    loaded = pickle.load(loadFile)
+            except FileNotFoundError: #fall back to a new server
+                loaded=Server(identity)
         return loaded
 
     def getWaifuByNameSource(self,name:str,source:str):

--- a/bot/guilds.py
+++ b/bot/guilds.py
@@ -52,6 +52,28 @@ class Server:
         self.options=ServerOption.defaultOptions()
         self.tickets=dict[int,int]()
 
+    def getStorageDict(self):
+        store = {}
+        store["identity"]=self.identity
+        store["waifus"]=[waifu.getStorageDict() for waifu in self.waifus]
+        store["polls"] =[poll.getStorageDict() for poll in self.polls]
+        store["options"]=self.options
+        store["tickets"]=self.tickets
+        return store
+
+    @staticmethod
+    def buildFromDict(serverDict:dict) -> Server:
+        loaded=Server(serverDict["identity"])
+        waifus=serverDict.get("waifus",[])
+        #logger.debug(str(waifus))
+        loaded.waifus=[Waifu.buildFromDict(waifuDict) for waifuDict in waifus]
+        polls=serverDict.get("polls",[])
+        #logger.debug(str(polls))
+        loaded.polls=[Poll.buildFromDict(pollDict) for pollDict in polls]
+        loaded.options=serverDict.get("options",loaded.options)
+        loaded.tickets=serverDict.get("tickets",loaded.tickets)
+        return loaded
+
     class ServerOption(Enum):
         #need to stick around for backward compatibility. Figure out how to get rid of these in stored guilds. all unused except when unpickling
         PollWaifuCount='pollSize' #how many waifus to put in a poll

--- a/bot/guilds.py
+++ b/bot/guilds.py
@@ -8,6 +8,7 @@ from polls import Poll, Waifu
 from headpatExceptions import *
 import matplotlib.pyplot as plt
 import numpy as np
+import yaml
 
 SAVE_FOLDER = os.path.join('guilds')
 if not os.path.exists(SAVE_FOLDER):
@@ -119,12 +120,22 @@ class Server:
         self.waifus.remove(toRemove)
 
     def save(self):
+        """
+            Saves the server to the file system
+        """
         filePath=os.path.join(SAVE_FOLDER,f'{self.identity}.p')
         with open(filePath,'wb') as saveFile:
             try:
                 pickle.dump(self,saveFile)
             except Exception as err:
                 logger.error(f'failed to pickle {self} with {err}')
+        
+        filePath=os.path.join(SAVE_FOLDER,f'{self.identity}.yaml')
+        with open(filePath,'w') as saveFile:
+            try:
+                yaml.safe_dump(self.getStorageDict(),saveFile)
+            except Exception as err:
+                logger.error(f'failed to yaml dump {self} with {err}')
 
     @property
     def asBytes(self):

--- a/bot/headpatBot.py
+++ b/bot/headpatBot.py
@@ -34,7 +34,7 @@ class HeadpatBot(commands.InteractionBot):
         self.logger.info(f"Logging in as {self.user}")
         for guild in self.guilds:
             try:
-                server = await database.getGuildPickle(guild.id)  # place 1 database is used
+                server = await database.getGuild(guild.id)  # place 1 database is used
                 server.save()
             except (UnpicklingError, TypeError, AttributeError):
                 pass

--- a/bot/headpatBot.py
+++ b/bot/headpatBot.py
@@ -44,9 +44,9 @@ class HeadpatBot(commands.InteractionBot):
 
     async def on_disconnect(self): #events to fire when closing
         self.logger.flush()
-        storageCog = self.get_cog('StorageCog')
-        await storageCog.storeFiles()
-        await storageCog.storeDatabase()
+        #storageCog = self.get_cog('StorageCog')
+        #await storageCog.storeFiles()
+        #await storageCog.storeDatabase()
 
     async def on_slash_command_error(
         self,
@@ -86,7 +86,7 @@ class HeadpatBot(commands.InteractionBot):
         #save pickle
         s.save()
         #add to database
-        await database.storeGuildPickle(s)                # place 2 database is used
+        await database.storeGuild(s)                # place 2 database is used
 
     async def on_guild_remove(
         self,

--- a/bot/headpatExceptions.py
+++ b/bot/headpatExceptions.py
@@ -5,3 +5,4 @@ class InsufficientTicketsError(Exception): pass
 class CollectionFullError(Exception): pass
 class UnreachableOptionsError(Exception): pass
 class InvalidOptionValueError(Exception): pass
+class InvalidPollStateError(Exception): pass


### PR DESCRIPTION
The idea here is to:

- Improve readability of stored objects
- Allow for easier refactors, as pickle directly references classes and modules and as such they cannot be renamed
- reduce some inter-linking of data that may have caused issues
- make caching errors more obvious

accomplished by allowing objects that need to be stored to convert themselves into dictionaries, and add factory methods to build from those dictionaries.
if a class moves, or attributes are adjusted, the factory method can be built to account for this, instead of relying on @property compatibility everywhere
objects are re-constructed on every reload, ensuring every attribute defined in constructor exists.